### PR TITLE
Bug fix: Menu close with no animation led to Null view crash

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -19,7 +19,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 201611270
-        versionName "1.0.3"
+        versionName "1.0.4"
     }
     buildTypes {
         release {
@@ -44,7 +44,7 @@ publish {
     userOrg = properties.getProperty("bintray.userOrg")
     groupId = properties.getProperty("bintray.groupId")
     artifactId = 'CircularFloatingActionMenu'
-    publishVersion = '1.0.3'
+    publishVersion = '1.0.4'
     description = 'An animated circular menu for Android'
     website = properties.getProperty("bintray.website")
     bintrayUser = properties.getProperty("bintray.user")

--- a/library/src/main/java/com/oguzdev/circularfloatingactionmenu/library/FloatingActionMenu.java
+++ b/library/src/main/java/com/oguzdev/circularfloatingactionmenu/library/FloatingActionMenu.java
@@ -242,7 +242,7 @@ public class FloatingActionMenu {
             for (int i = 0; i < subActionItems.size(); i++) {
                 removeViewFromCurrentContainer(subActionItems.get(i).view);
             }
-            detachOverlayContainer();
+            if (isSystemOverlay())  detachOverlayContainer();
         }
         // do not forget to specify that the menu is now closed.
         open = false;
@@ -475,7 +475,8 @@ public class FloatingActionMenu {
     }
 
     public void detachOverlayContainer() {
-        getWindowManager().removeView(overlayContainer);
+        if (overlayContainer != null)
+            getWindowManager().removeView(overlayContainer);
     }
 
     public int getStatusBarHeight() {


### PR DESCRIPTION
I've fixed menu close without animation crash in case if "System Overlay" option set to "false"